### PR TITLE
Use npm scripts to simplify the install process

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@
 
 ##Running
 
+####Before you start, tools your will need
+* Download and install [git](http://git-scm.com/downloads)
+* Download and install [nodeJS](http://nodejs.org/download/)
+
 ####First time:
+`git clone https://github.com/thomasstreet/famous-angular.git`
+
 `npm install`
 
-`npm install -g gulp`
-
-`git submodule update --init --recursive` 
-
 ####Thereafter:
-`gulp` 
+`npm start`
 
-Running gulp will concatenate files into famous.angular.js, which is symlinked into the app folder.  It will also watch for changes inside app and livereload as necessary.
+Npm start will use gulp to concatenate files into famous.angular.js, which is symlinked into the app folder. It will also watch for changes inside app and livereload as necessary.
 
 As configured, you should be able to access the application at localhost:4000.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "connect-livereload": "^0.4.0",
     "express": "^4.0.0",
     "grunt-contrib-jasmine": "~0.6.3",
-    "gulp": "^3.6.2",
+    "gulp": "~3.6.2",
     "gulp-autoprefixer": "0.0.7",
     "gulp-cache": "^0.1.3",
     "gulp-clean": "^0.2.4",
@@ -25,12 +25,16 @@
     "karma-jasmine": "~0.2.0",
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-ng-scenario": "^0.1.0",
-    "tiny-lr": "0.0.5"
+    "tiny-lr": "0.0.5",
+    "bower": "~1.3.3"
   },
   "engines": {
     "node": ">=0.8.0"
   },
   "scripts": {
+    "install": "bower install",
+	"postinstall": "git submodule update --init --recursive",
+	"start": "gulp",
     "test": "grunt test"
   }
 }


### PR DESCRIPTION
We can use the npm scripts to simplify the install process.
`npm install` will install npm modules, do a `bower install` and do a `git submodule update --init --recursive`

Using `npm start` to launch the server makes sense because it's a generic command.
If you decide to change gulp and use something else, just change the command in the package.json but your users will keep doing a `npm start` and won't have to change their habits
