### PR TITLE
Karma config for the tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,17 +7,23 @@ module.exports = function(config) {
     basePath: '',
 
     // testing framework to use (jasmine/mocha/qunit/...)
-    frameworks: ['jasmine'],
+    frameworks: ['jasmine', 'requirejs'],
 
     // list of files / patterns to load in the browser
     files: [
-      'angular/angular.js',
-      'angular-mocks/angular-mocks.js',
-      'angular-ui-router/release/angular-ui-router.min.js',
-      'angular-mocks/angular-mocks.js',
-      'requirejs/require.js',
-      'src/scripts/*.js',
-      'test/spec/*/*.js'
+	    'test/requirejs.config.js',
+	    'famous-angular-examples/app/bower_components/angular/angular.js',
+	    'bower_components/angular-mocks/angular-mocks.js',
+	    'famous-angular-examples/app/bower_components/angular-animate/angular-animate.js',
+	    'famous-angular-examples/app/bower_components/angular-ui-router/release/angular-ui-router.min.js',
+	    'famous-angular-examples/app/bower_components/requirejs/require.js',
+	    'famous-angular-examples/app/bower_components/underscore/underscore.js',
+	    'famous-angular-examples/app/bower_components/angular-touch/angular-touch.js',
+	    'http://code.famo.us/famous/0.2.0/famous.min.js',
+	    'dist/famous-angular.js',
+	    'famous-angular-examples/app/scripts/app.js',
+	    'famous-angular-examples/app/scripts/**/*js',
+	    'test/spec/**/*.js'
     ],
 
     // list of files / patterns to exclude

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "install": "bower install",
     "postinstall": "git submodule update --init --recursive",
     "start": "gulp dev",
-    "test": "grunt test"
+    "test": "karma start --single-run"
   },
   "dependencies": {},
   "devDependencies": {
@@ -34,6 +34,7 @@
     "gulp-exec": "^2.0.1",
     "gulp-header": "^1.0.2",
     "gulp-jshint": "^1.5.3",
+    "gulp-karma": "0.0.4",
     "gulp-livereload": "^1.3.1",
     "gulp-minify-css": "~0.3.1",
     "gulp-notify": "^1.2.5",
@@ -42,12 +43,15 @@
     "gulp-uglify": "^0.2.1",
     "gulp-util": "^2.2.14",
     "karma": "^0.12.1",
+    "karma-cli": "0.0.4",
     "karma-jasmine": "~0.2.0",
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-ng-scenario": "^0.1.0",
+    "karma-requirejs": "^0.2.1",
     "lodash": "^2.4.1",
     "minimist": "0.0.8",
     "mkdirp": "^0.5.0",
+    "requirejs": "^2.1.11",
     "semver": "^2.3.0",
     "winston": "^0.7.3"
   }

--- a/test/requirejs.config.js
+++ b/test/requirejs.config.js
@@ -1,0 +1,18 @@
+var tests = [];
+for (var file in window.__karma__.files) {
+	if (/^\/base\/test/.test(file)) {
+		tests.push(file);
+	}
+}
+
+requirejs.config({
+	// Karma serves files from '/base'
+	baseUrl: '/',
+
+	// ask Require.js to load these files (all our tests)
+	deps: tests,
+
+	// start test run, once Require.js is done
+	callback: window.__karma__.start
+});
+


### PR DESCRIPTION
Now that famous is available from a CDN, it has been possible to use karma for the tests.
I updated the old karma.conf.js file with the new dependencies.
You can test using `npm test` (don't forget to do a `npm install` and a `gulp build` before that).
Almost everything is failing since the tests haven't been updated for so long, but at least we have the basic test runner ! All we have to do now is write new tests (or update the existing ones).
