### PR TITLE
Adds missing backticks so tags render in docs.

### DIFF
--- a/src/scripts/directives/fa-view.js
+++ b/src/scripts/directives/fa-view.js
@@ -5,7 +5,7 @@
  * @restrict EA
  * @description
  * This directive is used to wrap child elements into a View render node.  This is especially useful for grouping.
- * Use an <fa-view> surrounded by a <fa-modifier> in order to affect the View's position, scale, etc.
+ * Use an `<fa-view>` surrounded by a `<fa-modifier>` in order to affect the View's position, scale, etc.
  *
  * @usage
  * ```html


### PR DESCRIPTION
Fixes this page:
https://famo.us/integrations/angular/docs/unstable/api/directive/faView/

So it renders the tags, instead of:
![screen shot 2014-05-23 at 3 43 00 pm](https://cloud.githubusercontent.com/assets/200635/3072645/a8c4c476-e2cb-11e3-9092-617ff90fffd8.png)

Thanks!
