### PR TITLE
fix: ensure that fa-modifier $observe callbacks will always fire at least once

### DIFF
--- a/src/scripts/directives/fa-modifier.js
+++ b/src/scripts/directives/fa-modifier.js
@@ -198,6 +198,10 @@ angular.module('famous.angular')
             });
 
             scope.$emit('registerChild', isolate);
+
+            // Trigger a $digest loop to make sure that callbacks for the
+            // $observe listeners are executed in the compilation phase.
+            if(!scope.$$phase) scope.$apply();
           }
         }
       }


### PR DESCRIPTION
Add $scope.$apply at the end of fa-modifier compilation to execute the callbacks for the $observe listeners.
