### PR TITLE
Cleaning up after fa-surface

### DIFF
--- a/src/scripts/directives/fa-app.js
+++ b/src/scripts/directives/fa-app.js
@@ -29,12 +29,12 @@ angular.module('famous.angular')
         return {
           pre: function(scope, element, attrs){
             var isolate = $famousDecorator.ensureIsolate(scope);
-            
+
             var View = $famous['famous/core/View'];
             var Engine = $famous['famous/core/Engine'];
             var Transform = $famous['famous/core/Transform']
 
-            
+
             element.append('<div class="famous-angular-container"></div>');
             isolate.context = Engine.createContext(element[0].querySelector('.famous-angular-container'));
 
@@ -95,6 +95,12 @@ angular.module('famous.angular')
             transclude(scope, function(clone) {
 	            angular.element(element[0].querySelectorAll('div div')[0]).append(clone);
             });
+
+            // Make the app Context available to child scopes of faApp.
+            scope.getContext = function() {
+              return isolate.context;
+            };
+
             isolate.readyToRender = true;
           }
         }

--- a/src/scripts/directives/fa-surface.js
+++ b/src/scripts/directives/fa-surface.js
@@ -33,9 +33,7 @@ angular.module('famous.angular')
             var isolate = $famousDecorator.ensureIsolate(scope);
 
             var Surface = $famous['famous/core/Surface'];
-            var Transform = $famous['famous/core/Transform']
-            var EventHandler = $famous['famous/core/EventHandler'];
-            
+
             //update properties
             //TODO:  is this going to be a bottleneck?
             scope.$watch(
@@ -82,6 +80,17 @@ angular.module('famous.angular')
             //boilerplate
             transclude(scope, function(clone) {
               angular.element(element[0].querySelectorAll('div.fa-surface')).append(clone);
+            });
+
+            // Remove DOM when the scope of an fa-surface is destroyed.
+            // We no longer have access to it at this point, so it's just taking up space.
+            scope.$on('$destroy', function() {
+              // Capture the dangling HTML node because Surface.cleanup will unset it
+              var containerNode = isolate.renderNode.content.parentNode;
+              // Invoke Surface.cleanup to unbind anything that might not get picked up by garbage collection
+              isolate.renderNode.cleanup(scope.getContext().getAllocator());
+              // Remove the dangling HTML node.
+              containerNode.parentNode.removeChild(containerNode);
             });
 
             scope.$emit('registerChild', isolate);


### PR DESCRIPTION
Addresses another situation where a scope.$destroy() leaves behind a bunch of stuff we can't even use anymore. Found not having this to be a performance hit when we have an ng-repeated set of fa-modifiers with fa-surfaces inside and splice something out of the ng-repeated array. Lots of stuff gets left behind, even though it's inaccessible everywhere in the application.

Gives faApp child scopes a method (getContext) that can be invoked to retrieve the isolate context created with Engine.createContext. This is needed to get the ElementAllocator used to invoke Surface.prototype.cleanup, which cleans up bindings. Then we remove the HTML it leaves behind.
