### PR TITLE
chore: remove tilde angular version at bower depdendency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,12 +6,12 @@
   "homepage": "https://github.com/Famous/famous-angular",
   "main": "dist/famous-angular.js",
   "dependencies": {
-    "angular": "1.2.16",
+    "angular": "1.2.18",
     "requirejs": ">=2.1.0",
     "famous": "~0.2.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.16"
+    "angular-mocks": "1.2.18"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Unable to find a suitable version for angular, please choose one:
    1) angular#1.2.16 which resolved to 1.2.16 and is required by famous-angular
    2) angular#1.2.18 which resolved to 1.2.18 and is required by angular-mocks#1.2.18

Set version to 1.2.18
