### PR TITLE
=BG= impl remove child for fa-header-footer-layout

### DIFF
--- a/src/scripts/directives/fa-header-footer-layout.js
+++ b/src/scripts/directives/fa-header-footer-layout.js
@@ -109,7 +109,7 @@ angular.module('famous.angular')
 
             $famousDecorator.sequenceWith(
               scope,
-              function(data) {
+              function addChild(data) {
                 _numberOfChildren++;
                 if (_numberOfChildren === 1) {
                   isolate.renderNode.header.add(data.renderGate);
@@ -121,9 +121,15 @@ angular.module('famous.angular')
                   throw new Error('fa-header-footer-layout can accept no more than 3 children');
                 }
               },
-              // TODO: support removing children
-              function(childScopeId) {
-                throw new Error ('unimplemented: fa-header-footer-layout does not support removing children');
+              function removeChild(childScopeId) {
+                if (_numberOfChildren === 1) {
+                  isolate.renderNode.header.set({});
+                } else if (_numberOfChildren === 2){
+                  isolate.renderNode.content.set({});
+                } else if (_numberOfChildren === 3){
+                  isolate.renderNode.footer.set({});
+                }
+                _numberOfChildren--;
               }
             );
 


### PR DESCRIPTION
- Fixes this issue (comment): https://github.com/Famous/famous-angular/issues/179#issuecomment-54391510
- ... without causing this issue, in another PR that attempts to fix the same thing, but breaks for me: https://github.com/Famous/famous-angular/pull/182#issuecomment-54584354

NOTE: It seems more right to do `isolate.rendernode.something.set(null)` instead of `isolate.rendernode.something.set({})`, however,
this breaks, as the `set` function in `RenderNode` currently does not handle a null parameter.
