### PR TITLE
Fix: BulkUpdate when removing a Draggable Object

### DIFF
--- a/dist/famous-angular.js
+++ b/dist/famous-angular.js
@@ -817,7 +817,7 @@ angular.module('famous.angular')
       for (var i = 0; i < pipes.length; i++) {
         for (var j = 0; j < targets.length; j++) {
           if (targets[j] !== undefined && pipes[i] !== undefined) {
-            targets[j][method](pipes[i]);
+              targets[j]._isModifier? targets[j]._object[method](pipes[i]) : targets[j][method](pipes[i]);
           }
         }
       }

--- a/src/scripts/services/famousPipe.js
+++ b/src/scripts/services/famousPipe.js
@@ -25,8 +25,10 @@ angular.module('famous.angular')
 
       for (var i = 0; i < pipes.length; i++) {
         for (var j = 0; j < targets.length; j++) {
-          if (targets[j] !== undefined && !targets[j]._object && pipes[i] !== undefined) {
-            targets[j][method](pipes[i]);
+          if (targets[j] !== undefined && pipes[i] !== undefined) {
+              if (targets[j]._object)
+                  targets[j]._object[method](pipes[i]);
+              else targets[j][method](pipes[i]);
           }
         }
       }

--- a/src/scripts/services/famousPipe.js
+++ b/src/scripts/services/famousPipe.js
@@ -26,9 +26,7 @@ angular.module('famous.angular')
       for (var i = 0; i < pipes.length; i++) {
         for (var j = 0; j < targets.length; j++) {
           if (targets[j] !== undefined && pipes[i] !== undefined) {
-              if (targets[j]._object)
-                  targets[j]._object[method](pipes[i]);
-              else targets[j][method](pipes[i]);
+            targets[j]._isModifier? targets[j]._object[method](pipes[i]) : targets[j][method](pipes[i]);
           }
         }
       }

--- a/src/scripts/services/famousPipe.js
+++ b/src/scripts/services/famousPipe.js
@@ -25,7 +25,7 @@ angular.module('famous.angular')
 
       for (var i = 0; i < pipes.length; i++) {
         for (var j = 0; j < targets.length; j++) {
-          if (targets[j] !== undefined && pipes[i] !== undefined) {
+          if (targets[j] !== undefined && !targets[j]._object && pipes[i] !== undefined) {
             targets[j][method](pipes[i]);
           }
         }


### PR DESCRIPTION
https://github.com/Famous/famous-angular/issues/185

When $destroy is called on a Draggable, from deleting an item in a ng-repeat or from ui-router. It appears that it goes through $destroy without testing if it's a modifier so it tries to renderNode.unpipe(EventHandler). I've corrected this by testing it again before updating the pipes.