### PR TITLE
docs: Fix typo in $timeline example

### DIFF
--- a/src/scripts/services/timeline.js
+++ b/src/scripts/services/timeline.js
@@ -9,7 +9,7 @@
  * @example
  * ```html
  * <fa-modifier
- *   fa-rotate-y="rRotation(t.get())"
+ *   fa-rotate-y="yRotation(t.get())"
  *   fa-translate="translation(t.get())"
  * >
  *   ...


### PR DESCRIPTION
- Fixes typo in function used in HTML template