### PR TITLE
Typo on line 12

### DIFF
--- a/src/scripts/services/timeline.js
+++ b/src/scripts/services/timeline.js
@@ -9,7 +9,7 @@
  * @example
  * ```html
  * <fa-modifier
- *   fa-rotate-y="rRotation(t.get())"
+ *   fa-rotate-y="yRotation(t.get())"
  *   fa-translate="translation(t.get())"
  * >
  *   ...


### PR DESCRIPTION
rRotation(t.get()) had no reference.  I believe this was a typo.  In markup, corrected to yRotation(t.get());