### PR TITLE
fix: ngClickDirective decorator can throw "$digest is already in progres...

### DIFF
--- a/src/scripts/directives/fa-input.js
+++ b/src/scripts/directives/fa-input.js
@@ -228,7 +228,7 @@ angular.module('famous.angular')
               });
 
               renderNode.on('click', function(event, touchend) {
-                scope.$apply(function() {
+                scope.$evalAsync(function() {
                   clickHandler(scope, {$event: (touchend || event)});
                 });
               });


### PR DESCRIPTION
The click event can be called multiple time and thus trigger multiple $apply causing a $digest error.
