### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Before you start, tools you will need:
 * Download and install [git](http://git-scm.com/downloads)
 * Download and install [nodeJS](http://nodejs.org/download/)
 
-####First time:
+#### First time:
 `git clone https://github.com/thomasstreet/famous-angular.git`
 
 `npm install`
@@ -12,7 +12,7 @@ Before you start, tools you will need:
 `npm install -g gulp`
 
 
-####Thereafter:
+#### Thereafter:
 Clone the submodules and install the frontend dependencies inside of your example folder.
 
 `git submodule update --init --recursive`
@@ -29,15 +29,15 @@ Npm start will use gulp to concatenate files into famous-angular.js, which is bu
 
 Then open http://localhost:4000.
 
-####To develop the library using the famous-angular-examples submodule
+#### To develop the library using the famous-angular-examples submodule
 
 `gulp dev`
 
-####To build the docs
+#### To build the docs
 
 `gulp docs`
 
-####To run tests
+#### To run tests
 Ensure that you have the [karma](http://karma-runner.github.io/0.12/intro/installation.html) command line interface installed.
 'npm install -g karma-cli'
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Using F/A, you can:
 * Use HTML to declare Famo.us UIs, complete with Angular's two-way databinding.
 * Easily integrate Famo.us and AngularJS apps.
 
-###Read More
+### Read More
 [Project Site](https://famo.us/angular)
 
 
-###Download
+### Download
 [Famo.us/Angular Starter Kit](http://code.famo.us/famous-angular/latest/famous-angular-starter-kit.zip?src=github-readme)
   or
 `bower install famous-angular`
 
 
-###Sample projects and generators
+### Sample projects and generators
 * [Famo.us/Angular Starter Project](https://github.com/thomasstreet/famous-angular-starter)
 * [fa-boilerplate starter repo](https://github.com/steveblue/fa-boilerplate) *(community maintained)
 * [Famo.us/Angular CodePen template](http://codepen.io/zackbrown/pen/yyVQje)
@@ -30,14 +30,14 @@ Using F/A, you can:
 
 
 
-##Installation
+## Installation
 
-####Before you start, tools you will need:
+#### Before you start, tools you will need:
 * Download and install [git](http://git-scm.com/downloads)
 * Download and install [nodeJS](http://nodejs.org/download/)
 * Install bower `npm install -g bower`
 
-####Inside of your app:
+#### Inside of your app:
 * Run `bower install famous-angular`
 * Add the following to your index.html
 ```html
@@ -63,19 +63,19 @@ Famous-Angular:
 * http://code.famo.us/famous-angular/latest/famous-angular.css
 
 
-##Support
+## Support
 
 * Feel free reach out for support on the Famous IRC channel on Freenode.  
 * Please submit issues as Github issues.  
 * Please create a CodePen forked from [this pen](http://codepen.io/zackbrown/pen/yyVQje) for all of you code issues.
 
 
-##Contributing
+## Contributing
 
 See [CONTRIBUTING.md](https://github.com/Famous/famous-angular/blob/master/CONTRIBUTING.md) for dev environment instructions and contribution guidelines.
 
 
-##Get in touch
+## Get in touch
 
 As mentioned above, please direct support questions to GitHub Issues so that community members can help answer questions as well as benefit from answers.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
